### PR TITLE
Chore/MATE-1646 Address GCC8 compilation warnings

### DIFF
--- a/C++/src/SeparatedInput.cpp
+++ b/C++/src/SeparatedInput.cpp
@@ -296,7 +296,7 @@ double SeparatedInput::getColumn(int i, double defaultValue, bool verbose) const
 	try {
 		rtn = Units::from(getUnitFactor(i), Util::parse_double(line_str[i]));
 	}
-	catch (std::runtime_error e) {
+	catch (const std::runtime_error &e) {
 		if (verbose) error.addWarning("could not parse double (" + Fm0(i) + "), line " + Fm0(linenum) + ": " + line_str[i]);
 		rtn = defaultValue;  // arbitrary value
 	}
@@ -360,7 +360,7 @@ bool SeparatedInput::readLine() {
 				try {
 					bunits = process_units(str);
 				}
-				catch (SeparatedInputException e) {
+				catch (const SeparatedInputException &e) {
 					// use default units
 					bunits = false;
 					process_line(str);
@@ -373,7 +373,7 @@ bool SeparatedInput::readLine() {
 			str.clear();
 		}  //while
 	}
-	catch (std::runtime_error e) {
+	catch (const std::runtime_error &e) {
 		error.addError(
 				"*** An IO error occurred at line " + Fm0(linenum)
 				+ "The error was:" + e.what());

--- a/C++/src/StateReader.cpp
+++ b/C++/src/StateReader.cpp
@@ -316,7 +316,7 @@ namespace larcfm {
       } else {
         tm = input.getColumn(head[TM_CLK], "s");
       }
-    } catch (std::runtime_error e) {
+    } catch (const std::runtime_error &e) {
       error.addError("error parsing time at line "+Fm0(input.lineNumber()));
     }
     return tm;

--- a/C++/src/Util.cpp
+++ b/C++/src/Util.cpp
@@ -514,7 +514,7 @@ double Util::parse_time(const string& s) {
 			tm = parse_double(fields2[0]); //getColumn(_sec, head[TM_CLK]);
 		}
 		return tm;
-	} catch (std::runtime_error e) {
+	} catch (const std::runtime_error &e) {
 		return -1.0;
 	}
 }


### PR DESCRIPTION
Runtime errors should be caught by const reference, rather than value.
Please refer to https://matternet.atlassian.net/browse/MATE-1646?atlOrigin=eyJpIjoiMDA3ODU2ZTYyNTUxNDNhMzkxZTU1MzFiYTM4NzU1MTQiLCJwIjoiaiJ9 for the full GCC compilation output.